### PR TITLE
chore: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,7 @@ jobs:
       run: npm run test:browser
 
     - name: Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Results
         path: test-results
-


### PR DESCRIPTION
v3 is no longer supported as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/